### PR TITLE
Update to use the new CEL interceptor

### DIFF
--- a/04-templatesandbindings/dev-cd-deploy-from-master-binding.yaml
+++ b/04-templatesandbindings/dev-cd-deploy-from-master-binding.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   params:
   - name: gitref
-    value: $(body.intercepted.ref)
-  - name: shortsha
-    value: $(body.intercepted.short_sha)
+    value: $(body.head_commit.id)
   - name: gitrepositoryurl
     value: $(body.repository.clone_url)

--- a/04-templatesandbindings/dev-cd-deploy-from-master-template.yaml
+++ b/04-templatesandbindings/dev-cd-deploy-from-master-template.yaml
@@ -9,8 +9,6 @@ spec:
     default: master
   - name: gitrepositoryurl
     description: The git repository url
-  - name: shortsha
-    description: A shortened version of the SHA for the commit to deploy
   resourcetemplates:
   - apiVersion: tekton.dev/v1alpha1
     kind: PipelineRun
@@ -34,4 +32,4 @@ spec:
             type: image
             params:
               - name: url
-                value: REPLACE_IMAGE:$(params.shortsha)
+                value: REPLACE_IMAGE:$(params.gitref)

--- a/04-templatesandbindings/dev-ci-build-from-pr-binding.yaml
+++ b/04-templatesandbindings/dev-ci-build-from-pr-binding.yaml
@@ -12,5 +12,3 @@ spec:
     value: $(body.repository.clone_url)
   - name: fullname
     value: $(body.repository.full_name)
-  - name: shortsha
-    value: $(body.intercepted.short_sha)

--- a/04-templatesandbindings/dev-ci-build-from-pr-template.yaml
+++ b/04-templatesandbindings/dev-ci-build-from-pr-template.yaml
@@ -10,8 +10,6 @@ spec:
     description: the specific commit SHA.
   - name: gitrepositoryurl
     description: The git repository url
-  - name: shortsha
-    description: A shortened version of the SHA for the commit to deploy
   - name: fullname
     description: The GitHub repository for this PullRequest.
   resourcetemplates:
@@ -42,4 +40,4 @@ spec:
             type: image
             params:
               - name: url
-                value: REPLACE_IMAGE:$(params.gitref)-$(params.shortsha)
+                value: REPLACE_IMAGE:$(params.gitref)-$(params.gitsha)

--- a/04-templatesandbindings/stage-cd-deploy-from-push-binding.yaml
+++ b/04-templatesandbindings/stage-cd-deploy-from-push-binding.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   params:
   - name: gitref
-    value: $(body.intercepted.ref)
+    value: $(body.ref)
   - name: gitsha
     value: $(body.commits.0.id)
   - name: gitrepositoryurl

--- a/08-eventlisteners/cicd-event-listener.yaml
+++ b/08-eventlisteners/cicd-event-listener.yaml
@@ -22,33 +22,17 @@ spec:
       template:
         name: dev-cd-deploy-from-master-template
     - name: stage-ci-dryrun-from-pr
-      interceptor:
-        header:
-        - name: Pullrequest-Action
-          value: opened,synchronize
-        - name:  Pullrequest-Repo
-          value: GITHUB_STAGE_REPO
-        objectRef:
-          kind: Service
-          name: demo-interceptor
-          apiVersion: v1
-          namespace: cicd-environment
+      interceptors:
+        - cel:
+            filter: (headers.match("X-GitHub-Event", "opened") || headers.match("X-GitHub-Event", "synchronize")) && body.pull_request.repo.full_name == "GITHUB_STAGE_REPO"
       binding:
         name: stage-ci-dryrun-from-pr-binding
       template:
         name: stage-ci-dryrun-from-pr-template
     - name: stage-cd-deploy-from-push
-      interceptor:
-        header:
-        - name: Push-Ref
-          value: master
-        - name:  Push-Repo
-          value: GITHUB_STAGE_REPO
-        objectRef:
-          kind: Service
-          name: demo-interceptor
-          apiVersion: v1
-          namespace: cicd-environment
+      interceptors:
+        - cel:
+            filter: (headers.match("X-GitHub-Event", "push") && body.pull_request.repo.full_name == "GITHUB_STAGE_REPO" && body.pull_request.repo.full_name.startsWith("/refs/heads/master")
       binding:
         name: stage-cd-deploy-from-push-binding
       template:

--- a/08-eventlisteners/cicd-event-listener.yaml
+++ b/08-eventlisteners/cicd-event-listener.yaml
@@ -6,17 +6,9 @@ spec:
   serviceAccountName: demo-sa
   triggers:
     - name: dev-ci-build-from-pr
-      interceptor:
-        header:
-        - name: Pullrequest-Action
-          value: opened,synchronize
-        - name:  Pullrequest-Repo
-          value: GITHUB_REPO
-        objectRef:
-          kind: Service
-          name: demo-interceptor
-          apiVersion: v1
-          namespace: cicd-environment
+      interceptors:
+        - cel:
+            filter: (headers.match("X-GitHub-Event", "opened") || headers.match("X-GitHub-Event", "synchronize")) && body.pull_request.repo.full_name == "GITHUB_REPO"
       binding:
         name: dev-ci-build-from-pr-binding
       template:

--- a/08-eventlisteners/cicd-event-listener.yaml
+++ b/08-eventlisteners/cicd-event-listener.yaml
@@ -14,17 +14,9 @@ spec:
       template:
         name: dev-ci-build-from-pr-template
     - name: dev-cd-deploy-from-master
-      interceptor:
-        header:
-        - name: Push-Ref
-          value: master
-        - name:  Push-Repo
-          value: GITHUB_REPO
-        objectRef:
-          kind: Service
-          name: demo-interceptor
-          apiVersion: v1
-          namespace: cicd-environment
+      interceptors:
+        - cel:
+            filter: (headers.match("X-GitHub-Event", "push") && body.pull_request.repo.full_name == "GITHUB_REPO" && body.pull_request.repo.full_name.startsWith("/refs/heads/master")
       binding:
         name: dev-cd-deploy-from-master-binding
       template:

--- a/08-eventlisteners/cicd-event-listener.yaml
+++ b/08-eventlisteners/cicd-event-listener.yaml
@@ -16,7 +16,7 @@ spec:
     - name: dev-cd-deploy-from-master
       interceptors:
         - cel:
-            filter: (header.match("X-GitHub-Event", "push") && body.repository.full_name == "GITHUB_REPO" && body.ref.startsWith("/refs/heads/master")
+            filter: (header.match("X-GitHub-Event", "push") && body.repository.full_name == "GITHUB_REPO") && body.ref.startsWith("refs/heads/master")
       bindings:
         - name: dev-cd-deploy-from-master-binding
       template:
@@ -32,7 +32,7 @@ spec:
     - name: stage-cd-deploy-from-push
       interceptors:
         - cel:
-            filter: (header.match("X-GitHub-Event", "push") && body.repository.full_name == "GITHUB_STAGE_REPO" && body.ref.startsWith("/refs/heads/master")
+            filter: (header.match("X-GitHub-Event", "push") && body.repository.full_name == "GITHUB_STAGE_REPO") && body.ref.startsWith("refs/heads/master")
       bindings:
         - name: stage-cd-deploy-from-push-binding
       template:

--- a/08-eventlisteners/cicd-event-listener.yaml
+++ b/08-eventlisteners/cicd-event-listener.yaml
@@ -8,32 +8,32 @@ spec:
     - name: dev-ci-build-from-pr
       interceptors:
         - cel:
-            filter: (headers.match("X-GitHub-Event", "opened") || headers.match("X-GitHub-Event", "synchronize")) && body.pull_request.repo.full_name == "GITHUB_REPO"
-      binding:
-        name: dev-ci-build-from-pr-binding
+            filter: (header.match("X-GitHub-Event", "pull_request") && body.action == "opened" || body.action == "synchronize") && body.pull_request.head.repo.full_name == "GITHUB_REPO"
+      bindings:
+        - name: dev-ci-build-from-pr-binding
       template:
         name: dev-ci-build-from-pr-template
     - name: dev-cd-deploy-from-master
       interceptors:
         - cel:
-            filter: (headers.match("X-GitHub-Event", "push") && body.pull_request.repo.full_name == "GITHUB_REPO" && body.pull_request.repo.full_name.startsWith("/refs/heads/master")
-      binding:
-        name: dev-cd-deploy-from-master-binding
+            filter: (header.match("X-GitHub-Event", "push") && body.repository.full_name == "GITHUB_REPO" && body.ref.startsWith("/refs/heads/master")
+      bindings:
+        - name: dev-cd-deploy-from-master-binding
       template:
         name: dev-cd-deploy-from-master-template
     - name: stage-ci-dryrun-from-pr
       interceptors:
         - cel:
-            filter: (headers.match("X-GitHub-Event", "opened") || headers.match("X-GitHub-Event", "synchronize")) && body.pull_request.repo.full_name == "GITHUB_STAGE_REPO"
-      binding:
-        name: stage-ci-dryrun-from-pr-binding
+            filter: (header.match("X-GitHub-Event", "pull_request") && body.action == "opened" || body.action == "synchronize") && body.pull_request.head.repo.full_name == "GITHUB_STAGE_REPO"
+      bindings:
+        - name: stage-ci-dryrun-from-pr-binding
       template:
         name: stage-ci-dryrun-from-pr-template
     - name: stage-cd-deploy-from-push
       interceptors:
         - cel:
-            filter: (headers.match("X-GitHub-Event", "push") && body.pull_request.repo.full_name == "GITHUB_STAGE_REPO" && body.pull_request.repo.full_name.startsWith("/refs/heads/master")
-      binding:
-        name: stage-cd-deploy-from-push-binding
+            filter: (header.match("X-GitHub-Event", "push") && body.repository.full_name == "GITHUB_STAGE_REPO" && body.ref.startsWith("/refs/heads/master")
+      bindings:
+        - name: stage-cd-deploy-from-push-binding
       template:
         name: stage-cd-deploy-from-push-template

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -49,7 +49,7 @@ sed $SED_OPTIONS "s|GITHUB_STAGE_REPO|${GITHUB_STAGE_REPO}|g" 08-eventlisteners/
 sed $SED_OPTIONS "s|DEPLOYMENT_PATH|${DEPLOYMENT_PATH}|g" 07-cd/*.yaml
 
 oc apply -f https://github.com/tektoncd/pipeline/releases/download/v0.9.1/release.yaml
-oc apply -f https://github.com/tektoncd/triggers/releases/download/v0.1.0/release.yaml
+oc apply -f https://github.com/tektoncd/triggers/releases/download/v0.2.0/release.yaml
 oc new-project dev-environment
 oc new-project stage-environment
 oc new-project cicd-environment

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -62,7 +62,6 @@ oc create rolebinding demo-sa-admin-dev --clusterrole=admin --serviceaccount=cic
 oc create rolebinding demo-sa-admin-stage --clusterrole=admin --serviceaccount=cicd-environment:demo-sa --namespace=stage-environment
 oc apply -f 03-tasks
 oc apply -f 04-templatesandbindings
-oc apply -f 05-interceptor
 oc apply -f 06-ci
 oc apply -f 07-cd
 oc apply -f 08-eventlisteners

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,8 +48,8 @@ sed $SED_OPTIONS "s|GITHUB_REPO|${GITHUB_REPO}|g" 08-eventlisteners/cicd-event-l
 sed $SED_OPTIONS "s|GITHUB_STAGE_REPO|${GITHUB_STAGE_REPO}|g" 08-eventlisteners/cicd-event-listener.yaml
 sed $SED_OPTIONS "s|DEPLOYMENT_PATH|${DEPLOYMENT_PATH}|g" 07-cd/*.yaml
 
-oc apply -f https://github.com/tektoncd/pipeline/releases/download/v0.9.1/release.yaml
-oc apply -f https://github.com/tektoncd/triggers/releases/download/v0.2.0/release.yaml
+oc apply -f https://github.com/tektoncd/pipeline/releases/download/v0.10.1/release.yaml
+oc apply -f https://github.com/tektoncd/triggers/releases/download/v0.2.1/release.yaml
 oc new-project dev-environment
 oc new-project stage-environment
 oc new-project cicd-environment


### PR DESCRIPTION
This upgrades Pipeline and Triggers to 0.10.1 and 0.2.1 respectively, and updates the resources to use the latest naming conventions.

Drops usage of the old webhook interceptor in favour of the CEL interceptor, this does mean that the SHAs are not shortened, but this is coming back soon https://github.com/tektoncd/triggers/pull/329